### PR TITLE
rsa: big exponents are exponents, too!

### DIFF
--- a/src/rsa.iced
+++ b/src/rsa.iced
@@ -195,7 +195,6 @@ class Pub extends BaseKey
     err = if (not @n.gcd(@e).equals(BigInteger.ONE)) then new Error "gcd(n,e) != 1"
     else if (not @n.mod(nbv(2)).equals(BigInteger.ONE)) then new Error "n % 2 != 1"
     else if (@e.compareTo(BigInteger.ONE) <= 0) then new Error "e <= 1"
-    else if (@e.compareTo(nbv(0x10001)) > 0) then new Error "e > (2^16 + 1)"
     else if not naive_is_prime(@e.intValue()) then new Error "e isn't prime!"
     else null
     cb err


### PR DESCRIPTION
The key validity check barfs on exponents larger than 2^16+1.  However, there's no real reason why exponents have to be smaller than that -- those are perfectly legal exponents, and Scallion generates keys that have quite large exponents indeed!  (For instance, my key, 0x9080C092EA80E0B4, has exponent 0xE8BD99D9.)

This pull request removes that restriction.

(Verified: passed 'make test'.)
