### PR TITLE
SignaturePacket: fixes typo in signature type switches with T.persona

### DIFF
--- a/lib/openpgp/packet/signature.js
+++ b/lib/openpgp/packet/signature.js
@@ -461,7 +461,7 @@
           case T.canonical_text:
             return data_packets;
           case T.issuer:
-          case T.personal:
+          case T.persona:
           case T.casual:
           case T.positive:
           case T.certificate_revocation:
@@ -562,7 +562,7 @@
                 }
                 break;
               case T.issuer:
-              case T.personal:
+              case T.persona:
               case T.casual:
               case T.positive:
                 ps = null;
@@ -636,7 +636,7 @@
     Signature.prototype.time_primary_pair = function() {
       var T, _ref3, _ref4;
       T = C.sig_types;
-      if ((_ref3 = this.type) === T.issuer || _ref3 === T.personal || _ref3 === T.casual || _ref3 === T.positive) {
+      if ((_ref3 = this.type) === T.issuer || _ref3 === T.persona || _ref3 === T.casual || _ref3 === T.positive) {
         return [this.when_generated(), !!((_ref4 = this.subpacket_index.hashed[S.primary_user_id]) != null ? _ref4.flag : void 0)];
       } else {
         return null;
@@ -649,7 +649,7 @@
       T = C.sig_types;
       key_expiration = 0;
       sig_expiration = 0;
-      if ((_ref3 = this.type) === T.issuer || _ref3 === T.personal || _ref3 === T.casual || _ref3 === T.positive || _ref3 === T.subkey_binding || _ref3 === T.primary_binding) {
+      if ((_ref3 = this.type) === T.issuer || _ref3 === T.persona || _ref3 === T.casual || _ref3 === T.positive || _ref3 === T.subkey_binding || _ref3 === T.primary_binding) {
         key_creation = (opts.subkey || this.primary).timestamp;
         key_expiration_packet = this.subpacket_index.hashed[S.key_expiration_time];
         sig_creation_packet = this.subpacket_index.hashed[S.creation_time];

--- a/src/openpgp/packet/signature.iced
+++ b/src/openpgp/packet/signature.iced
@@ -233,7 +233,7 @@ class Signature extends Packet
     @data_packets = switch @type
       when T.binary_doc, T.canonical_text then data_packets
 
-      when T.issuer, T.personal, T.casual, T.positive, T.certificate_revocation
+      when T.issuer, T.persona, T.casual, T.positive, T.certificate_revocation
 
         if (n = data_packets.length) isnt 1
           err = new Error "Only expecting one UserID-style packet in a self-sig (got #{n})"
@@ -294,7 +294,7 @@ class Signature extends Packet
           for d in @data_packets
             d.push_sig new packetsigs.Data { sig }
 
-        when T.issuer, T.personal, T.casual, T.positive
+        when T.issuer, T.persona, T.casual, T.positive
           ps = null
           if (userid = @data_packets[1].to_userid())?
             ps = new packetsigs.SelfSig { @type, userid, sig }
@@ -329,7 +329,7 @@ class Signature extends Packet
 
   time_primary_pair : () ->
     T = C.sig_types
-    if @type in [ T.issuer, T.personal, T.casual, T.positive ]
+    if @type in [ T.issuer, T.persona, T.casual, T.positive ]
       [ @when_generated(), !!(@subpacket_index.hashed[S.primary_user_id]?.flag) ]
     else
       null
@@ -344,7 +344,7 @@ class Signature extends Packet
     key_expiration = 0
     sig_expiration = 0
 
-    if @type in [ T.issuer, T.personal, T.casual, T.positive, T.subkey_binding, T.primary_binding ]
+    if @type in [ T.issuer, T.persona, T.casual, T.positive, T.subkey_binding, T.primary_binding ]
 
       key_creation = (opts.subkey or @primary).timestamp
       key_expiration_packet = @subpacket_index.hashed[S.key_expiration_time]


### PR DESCRIPTION
In openppg/packet/signature.iced are multiple checks against the current signature type. All of them compare against a non existing Type T.personal which seems to be a typo of T.persona

```javascript
 52   sig_types :  # See RFC 4880 5.2.1. Signature Types
 53     binary_doc : 0x00
 54     canonical_text : 0x01
 55     issuer : 0x10
 56     persona : 0x11
```