### PR TITLE
Do not use Buffer without 'new'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "node"
+  - "6"
   - "5"
   - "4"
 notifications:

--- a/test/files/buffer_shift_right.iced
+++ b/test/files/buffer_shift_right.iced
@@ -24,7 +24,7 @@ exports.test_buffer_shift_right = (T,cb) ->
 
       # We need to add a leading '0' back so that we still have
       # 4 bytes of data, so compare works to a standard 32-bit integer
-      b3 = Buffer.concat [ Buffer(0 for [0...(shift >> 3)] ), b3 ]
+      b3 = Buffer.concat [ new Buffer(0 for [0...(shift >> 3)] ), b3 ]
       T.assert bufeq_fast(b3,b2), "Buffer #{j}, shift=#{shift}"
 
   cb()


### PR DESCRIPTION
Fixes 

```
(node:3922) DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc() instead.
``` 

in node 7.

Also took the liberty to add more versions to `.travis.yml`. Compiles and tests fine on both 6 and 7, you can see here on my repo test branch: https://travis-ci.org/zapu/kbpgp; or in CI of this PR, apparently it uses the proposed `.travis.yml`