### PR TITLE
Fix P521 point encoding disagreement with GnuPG

### DIFF
--- a/lib/ecc/curves.js
+++ b/lib/ecc/curves.js
@@ -93,7 +93,7 @@
     };
 
     Curve.prototype.point_to_mpi_buffer_compact = function(p) {
-      return p.affineX.toBuffer(this.p.byteLength());
+      return p.affineX.toBuffer(this.mpi_coord_byte_size());
     };
 
     Curve.prototype.point_to_mpi_buffer = function(p) {

--- a/src/ecc/curves.iced
+++ b/src/ecc/curves.iced
@@ -78,7 +78,7 @@ exports.Curve = class Curve extends base.Curve
 
   #----------------------------------
 
-  point_to_mpi_buffer_compact : (p) -> p.affineX.toBuffer @p.byteLength()
+  point_to_mpi_buffer_compact : (p) -> p.affineX.toBuffer @mpi_coord_byte_size()
 
   #----------------------------------
 


### PR DESCRIPTION
This change fixes nist p521 ecdh encryption errors with certain secret keys. 

You can see the bug in action here: https://asciinema.org/a/36rc4x3rjd7u3ef43j8stam6h (1:30 recording, or you can watch from 1:00 onward to see the actual decryption uncertainty).

For some numbers `p.byteLength()` will be smaller than `@mpi_coord_byte_size()` and GnuPG does not handle this. The bignum encoded is still correct - you can decode it and get the exact same number - but the leading 0x00s are needed there.
