### PR TITLE
Be less strict about MPI encoding for ECDH encrypted keys

### DIFF
--- a/src/ecc/curves.iced
+++ b/src/ecc/curves.iced
@@ -173,7 +173,7 @@ exports.Curve25519 = class Curve25519 extends Curve
       throw new Error "Not enough bytes for 25519 point. Need at least #{point_bytes}, got #{n_bytes - 1}."
     else if skip_bytes > 0
       padding = sb.read_buffer(skip_bytes)
-      if not padding.every((x) -> x == 0)
+      unless padding.every((x) -> x is 0)
         # This is not compatible with GnuPG - gpg2 will just skip
         # bytes, shall they be 0s or not.
         throw new Error "Number is too big to be a 25519 point."

--- a/src/ecc/curves.iced
+++ b/src/ecc/curves.iced
@@ -35,6 +35,9 @@ exports.Curve = class Curve extends base.Curve
     # Rounding up needed for p521, and 3 bits needed to represent the leading 0x4
     2*@mpi_coord_bit_size() + 3
 
+  mpi_byte_size : () ->
+    Math.ceil(@mpi_bit_size() / 8)
+
   #----------------------------------
 
   mpi_coord_byte_size : () -> Math.ceil(@nbits()/8)
@@ -52,11 +55,14 @@ exports.Curve = class Curve extends base.Curve
   _mpi_point_from_slicer_buffer : (sb) ->
     n_bits = sb.read_uint16()
     n_bytes = Math.ceil(n_bits/8)
+    if n_bytes isnt (b = @mpi_byte_size())
+      bits = @mpi_bit_size()
+      throw new Error "Need #{b} bytes (#{bits} bits) for this curve; got #{n_bytes} (#{n_bits} bits)"
     if sb.read_uint8() isnt 0x4
       throw new Error "Can only handle 0x4 prefix for MPI representations"
-    n_coord_bytes = (n_bytes - 1) / 2 # -1 byte for 0x4 prefix
-    [x,y] = [ BigInteger.fromBuffer(sb.read_buffer(n_coord_bytes)), BigInteger.fromBuffer(sb.read_buffer(n_coord_bytes))]
-    point = @mkpoint { x, y } 
+    coord_bytes = @mpi_coord_byte_size()
+    [x,y] = [ BigInteger.fromBuffer(sb.read_buffer(coord_bytes)), BigInteger.fromBuffer(sb.read_buffer(coord_bytes)) ]
+    point = @mkpoint { x, y} 
     unless @isOnCurve point
       throw new Error "Given ECC point isn't on the given curve; data corruption detected."
     [ null, point ]
@@ -164,23 +170,16 @@ exports.Curve25519 = class Curve25519 extends Curve
   _mpi_point_from_slicer_buffer : (sb) ->
     n_bits = sb.read_uint16()
     n_bytes = Math.ceil(n_bits/8)
+    if n_bytes isnt (b = @mpi_byte_size())
+      bits = @mpi_bit_size()
+      throw new Error "Need #{b} bytes (#{bits} bits) for this curve; got #{n_bytes} (#{n_bits} bits)"
     if sb.read_uint8() isnt 0x40
       throw new Error "Can only handle 0x40 prefix for 25519 MPI representations"
 
-    point_bytes = @nbits()/8
-    skip_bytes = n_bytes - point_bytes - 1
-    if skip_bytes < 0
-      throw new Error "Not enough bytes for 25519 point. Need at least #{point_bytes}, got #{n_bytes - 1}."
-    else if skip_bytes > 0
-      padding = sb.read_buffer(skip_bytes)
-      unless padding.every((x) -> x is 0)
-        # This is not compatible with GnuPG - gpg2 will just skip
-        # bytes, shall they be 0s or not.
-        throw new Error "Number is too big to be a 25519 point."
-
     # Point is just a 32-byte buffer. We also do not validate it,
     # because DJB told us not to: https://cr.yp.to/ecdh.html
-    point = sb.read_buffer(point_bytes)
+    n_bytes = @mpi_coord_byte_size()
+    point = sb.read_buffer(n_bytes)
 
     [ null, point ]
 

--- a/src/ecc/curves.iced
+++ b/src/ecc/curves.iced
@@ -51,13 +51,12 @@ exports.Curve = class Curve extends base.Curve
   #
   _mpi_point_from_slicer_buffer : (sb) ->
     n_bits = sb.read_uint16()
-    if n_bits isnt (b = @mpi_bit_size())
-      throw new Error "Need #{b} bits for this curve; got #{n_bits}"
+    n_bytes = Math.ceil(n_bits/8)
     if sb.read_uint8() isnt 0x4
       throw new Error "Can only handle 0x4 prefix for MPI representations"
-    n_bytes = @mpi_coord_byte_size()
-    [x,y] = [ BigInteger.fromBuffer(sb.read_buffer(n_bytes)), BigInteger.fromBuffer(sb.read_buffer(n_bytes)) ]
-    point = @mkpoint { x, y} 
+    n_coord_bytes = (n_bytes - 1) / 2 # -1 byte for 0x4 prefix
+    [x,y] = [ BigInteger.fromBuffer(sb.read_buffer(n_coord_bytes)), BigInteger.fromBuffer(sb.read_buffer(n_coord_bytes))]
+    point = @mkpoint { x, y } 
     unless @isOnCurve point
       throw new Error "Given ECC point isn't on the given curve; data corruption detected."
     [ null, point ]
@@ -164,15 +163,24 @@ exports.Curve25519 = class Curve25519 extends Curve
 
   _mpi_point_from_slicer_buffer : (sb) ->
     n_bits = sb.read_uint16()
-    if n_bits isnt (b = @mpi_bit_size())
-      throw new Error "Need #{b} bits for this curve; got #{n_bits}"
+    n_bytes = Math.ceil(n_bits/8)
     if sb.read_uint8() isnt 0x40
       throw new Error "Can only handle 0x40 prefix for 25519 MPI representations"
 
+    point_bytes = @nbits()/8
+    skip_bytes = n_bytes - point_bytes - 1
+    if skip_bytes < 0
+      throw new Error "Not enough bytes for 25519 point. Need at least #{point_bytes}, got #{n_bytes - 1}."
+    else if skip_bytes > 0
+      padding = sb.read_buffer(skip_bytes)
+      if not padding.every((x) -> x == 0)
+        # This is not compatible with GnuPG - gpg2 will just skip
+        # bytes, shall they be 0s or not.
+        throw new Error "Number is too big to be a 25519 point."
+
     # Point is just a 32-byte buffer. We also do not validate it,
     # because DJB told us not to: https://cr.yp.to/ecdh.html
-    n_bytes = @mpi_coord_byte_size()
-    point = sb.read_buffer(n_bytes)
+    point = sb.read_buffer(point_bytes)
 
     [ null, point ]
 

--- a/test/files/cv25519.iced
+++ b/test/files/cv25519.iced
@@ -110,6 +110,50 @@ Sw2kTR6zDozs4Qw/EBc7mDHVfuRTuEeMC25U8G9wbSc0nYqTpPbDab1SIxY1nReA
   T.equal msg[0].toString(), "wow so many 0s", "got the right plaintext"
   cb()
 
+exports.decrypt_coord_too_short_cv25519 = (T, cb) ->
+  # This time the coordinate is too short. This does not pass in GnuPG.
+  # It actually is a valid V:
+  # 00197794700e0f6d7409b1af8ba958862058840357d93e374e4af39b3c6be246
+  # But the first 00 is dropped when encoding point.
+
+  msg = """-----BEGIN PGP MESSAGE-----
+Version: Keybase OpenPGP v2.0.62
+Comment: https://keybase.io/crypto
+
+wV0DR1BH23/8iIwSAP9AGXeUcA4PbXQJsa+LqViGIFiEA1fZPjdOSvObPGviRjDh
+Q7OyQAbgeaxYfpagOf8Cnt+CBwRUPU91D1BIr9yj7p5bm0/AI8YuRz6mO09LjxfS
+SgEaRMTqZ6PbEmCEJIZPijvFQkDTwSVBnSQpzmSYX897PRfMPTZybmFX4BurM9js
+xeRNX6s2Gmf3MOJDDsICvEU3M6163RmpIWBY
+=pFxy
+-----END PGP MESSAGE-----
+
+"""
+
+  await do_message { armored: msg, keyfetch: km }, defer err, msg
+  T.assert err?, "decryption should fail"
+  cb()
+
+exports.decrypt_coord_too_big_cv25519 = (T, cb) ->
+  # Somehow the V ended up being bigger than 256 bits. It will pass in
+  # GnuPG though... apparently it just skips bytes and uses last 32 as
+  # coordinate.
+  msg = """-----BEGIN PGP MESSAGE-----
+Version: Keybase OpenPGP v2.0.62
+Comment: https://keybase.io/crypto
+
+wV8DR1BH23/8iIwSAQ9AAc1Jzd7d9cTVtaitnuILUNMndMBjgnOeTjGaN4LsNd8V
+MEOKiugoecp68CzBl4acXwwEiO4bjVT1QUNSCWyn9/iR3UNKpJdsOp5+wI/bUi+x
+AdJKAR7FUwOg7qHUoS8KUARlejABAJb2JbQHXh/niitHfMKXk7cbuDdb6PHAi5KG
+fm/yDg7EKpgIu9e6IbQsi7wcX8uhWL0L/ByBAxk=
+=B/AV
+-----END PGP MESSAGE-----
+
+"""
+
+  await do_message { armored: msg, keyfetch: km }, defer err, msg
+  T.assert err?, "decryption should fail"
+  cb()
+
 exports.decrypt_verify_gpg2_issued_payload = (T, cb) ->
   cipher = """-----BEGIN PGP MESSAGE-----
 

--- a/test/files/p521.iced
+++ b/test/files/p521.iced
@@ -49,3 +49,43 @@ exports.roundtrip_nistp521 = (T, cb) ->
   T.no_error err
   T.equal plaintext, msg[0].toString(), "decrypted text matches plaintext"
   cb()
+
+exports.decrypt_padded_v_521 = (T, cb) ->
+  ###
+  This weird message (notice the "AAAAAA..." in payload) is a valid
+  ECDH encrypted message, but the secret coordinates are encoded with
+  a lot more bits that the curve's coordinate size. GPG and go-crypto
+  take this message without problems, but KBPGP is a bit more strict
+  and fails with:
+
+  Error: Need 1059 bits for this curve; got 1459
+  at Curve.exports.Curve.Curve._mpi_point_from_slicer_buffer
+
+  istack:
+   [ 'Priv::decrypt',
+     'Message::decrypt',
+     'Message:process',
+     'Message::parse_and_process' ] }
+  ###
+
+  armored_msg = """-----BEGIN PGP MESSAGE-----
+Version: Keybase OpenPGP v2.0.58
+Comment: https://keybase.io/crypto
+
+wcA0A6pi0WoSlxTXEgWzBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/ZTuFZa3
+go5bAv8SLZd5vTQzjQiqiXfaQUX3dQu+zytgEeiugIshlJ7JykTPGhdQFVSiKQYe
+a4RKpgbn8SkNhyIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAaR1kL+5vnf9E0wv
+vGDKg1jo0uEGYVodxTwk8QuqbxWiCT/jOH9kybjECSPlkDkbUIOezOfaTlwde0Wo
+XUNWZ/WrMOJHerpQvMvPNjEwMSGnsIZPh8/Hafj7j8OauMG5EWgCrzsxv1mgsRXP
+QkNog/5dM9JIAcT8RpDaFecdhRag6ZPuRKmNuhiFtR7o0spcqX2UkJ3FPB7UydX3
+ch9PkTNL1BVD++JqYQE9eaIqlCTAsHwCgO6pQkQqPUvB
+=y7cW
+-----END PGP MESSAGE-----
+
+
+"""
+
+  await top.unbox { armored: armored_msg, keyfetch: km }, defer err, plain
+  T.no_error err
+  T.equal "purpleschala", plain[0].toString(), "decrypted text matches plaintext"
+  cb()


### PR DESCRIPTION
This is alternative to https://github.com/keybase/kbpgp/pull/134

The spec says that MPI should have exact size:
```
   Therefore, the exact size of the MPI payload is 515 bits for "Curve
   P-256", 771 for "Curve P-384", and 1059 for "Curve P-521".
```

But GnuPG appears to accept anything that results in a good number after decoding (so any amount of zero-padding and `size` field being not necessarily exact number of bits). The other PR copies this behavior; **this one is only less strict about `size` field** - the MPI size has match rounded to full bytes.