### PR TITLE
Fix EDDSA/ECDH serialization

### DIFF
--- a/src/ecc/curves.iced
+++ b/src/ecc/curves.iced
@@ -107,6 +107,17 @@ exports.Curve = class Curve extends base.Curve
 
   #----------------------------------
 
+  # Serialize single curve coordinate (usually private key X) to MPI
+  # buffer, with 2-byte header encoding bit-size of the coordinate.
+  coord_to_mpi_buffer : (p) ->
+    byte_size = @mpi_coord_byte_size()
+    Buffer.concat [
+      uint_to_buffer(16, byte_size * 8),
+      p.toBuffer byte_size
+    ]
+
+  #----------------------------------
+
   # The small buffer type - where the format is:
   # (u16 - number of bits)(buffer - number; of said length)
   mpi_from_buffer : (raw) -> bn.mpi_from_buffer raw
@@ -205,6 +216,18 @@ exports.Curve25519 = class Curve25519 extends Curve
     # secret-key trimming, so we don't have to. Everything we give to
     # scalarmult or scalarmult_base will be a valid cv25519 secret.
     SRF().random_bytes @mpi_coord_byte_size(), cb
+
+  #----------------------------------
+
+  # Serialize single curve coordinate (usually private key X) to MPI
+  # buffer, with 2-byte header encoding bit-size of the coordinate.
+  coord_to_mpi_buffer : (p) ->
+    byte_size = @mpi_coord_byte_size()
+    throw new Error "Invalid p.length: got #{p.length} expected #{byte_size}." if p.length != byte_size
+    Buffer.concat [
+      uint_to_buffer(16, byte_size * 8),
+      p
+    ]
 
   #----------------------------------
 

--- a/src/ecc/curves.iced
+++ b/src/ecc/curves.iced
@@ -223,7 +223,6 @@ exports.Curve25519 = class Curve25519 extends Curve
   # buffer, with 2-byte header encoding bit-size of the coordinate.
   coord_to_mpi_buffer : (p) ->
     byte_size = @mpi_coord_byte_size()
-    throw new Error "Invalid p.length: got #{p.length} expected #{byte_size}." if p.length != byte_size
     Buffer.concat [
       uint_to_buffer(16, byte_size * 8),
       p

--- a/src/ecc/ecdh.iced
+++ b/src/ecc/ecdh.iced
@@ -122,7 +122,10 @@ class Priv extends BaseKey
 
   #-------------------
 
-  serialize : () -> @x.to_mpi_buffer()
+  serialize : () ->
+    {curve} = @pub
+    curve.coord_to_mpi_buffer @x
+
   @alloc : (raw, pub) ->
     orig_len = raw.length
     err = null

--- a/src/ecc/eddsa.iced
+++ b/src/ecc/eddsa.iced
@@ -63,10 +63,10 @@ class Pub extends BaseKey
     oid = sb.read_buffer(l)
     expected = Pub.OID
     unless util.bufeq_secure oid, expected
-      new Error "Wrong OID in EdDSA key"
+      throw new Error "Wrong OID in EdDSA key"
     mpi_length_headers = sb.read_buffer Pub.MPI_LENGTH_HEADERS.length
     unless util.bufeq_secure mpi_length_headers, Pub.MPI_LENGTH_HEADERS
-      new Error "Wrong MPI length headers"
+      throw new Error "Wrong MPI length headers"
     key = sb.read_buffer kbnacl.sign.publicKeyLength
     pub = new Pub { key }
     len = pre - sb.rem()
@@ -146,9 +146,6 @@ class Priv extends BaseKey
   #-------------------    
 
   serialize : () ->
-    if (m = @seed.length) != (n = kbnacl.sign.seedLength)
-      throw new Error "Serialize failed: expected @seed to be #{n} bytes, got #{m} bytes."
-
     # We can't use base class method, because again, our keys are
     # buffers, not bigints.
     Buffer.concat [ 

--- a/src/ecc/eddsa.iced
+++ b/src/ecc/eddsa.iced
@@ -146,10 +146,13 @@ class Priv extends BaseKey
   #-------------------    
 
   serialize : () ->
+    if (m = @seed.length) != (n = kbnacl.sign.seedLength)
+      throw new Error "Serialize failed: expected @seed to be #{n} bytes, got #{m} bytes."
+
     # We can't use base class method, because again, our keys are
     # buffers, not bigints.
     Buffer.concat [ 
-      uint_to_buffer(16, kbnacl.sign.seedLength),
+      uint_to_buffer(16, kbnacl.sign.seedLength*8),
       @seed
     ]
 


### PR DESCRIPTION
Neither was serializing correctly, and Cv25519 was even failing with an exception.

Added tests that creates eddsa/cv25519 key and reimports it to check the serialization. It should probably also check if returning key has the same params, it only checks if it went through without errors now.