### PR TITLE
Add assert_pgp_hash callback for signature verification (unbox)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.7 (2020-01-16)
+
+- Add `assert_pgp_hash` arguments so API consumers can reject hash algorithms.
+- Add `hasher` when boxing / signing so default hash algorithm (SHA512) can be
+  overridden if needed.
+
 ## 2.1.6 (2019-11-04)
 
 - fix tests

--- a/lib/openpgp/burner.js
+++ b/lib/openpgp/burner.js
@@ -128,13 +128,14 @@
     };
 
     Burner.prototype._sign = function(cb) {
-      var esc, fp, ops, ops_framed, sig, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var esc, fp, hasher, ops, ops_framed, sig, ___iced_passed_deferral, __iced_deferrals, __iced_k, _ref3, _ref4;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
-      esc = make_esc(cb, "Burner::_sign'");
+      esc = make_esc(cb, "Burner::_sign");
+      hasher = (_ref3 = (_ref4 = this.opts) != null ? _ref4.hasher : void 0) != null ? _ref3 : SHA512;
       ops = new OnePassSignature({
         sig_type: C.sig_types.binary_doc,
-        hasher: SHA512,
+        hasher: hasher,
         sig_klass: this.signing_key.get_klass(),
         key_id: this.signing_key.get_key_id(),
         is_final: 1
@@ -152,17 +153,18 @@
                 return ops_framed = arguments[0];
               };
             })(),
-            lineno: 67
+            lineno: 68
           })));
           __iced_deferrals._fulfill();
         });
       })(this)((function(_this) {
         return function() {
-          var _ref3;
+          var _ref5;
           sig = new Signature({
             type: C.sig_types.binary_doc,
+            hasher: hasher,
             key: _this.signing_key.key,
-            hashed_subpackets: [new CreationTime(((_ref3 = _this.opts) != null ? _ref3.now : void 0) || unix_time())],
+            hashed_subpackets: [new CreationTime(((_ref5 = _this.opts) != null ? _ref5.now : void 0) || unix_time())],
             unhashed_subpackets: [new Issuer(_this.signing_key.get_key_id())]
           });
           (function(__iced_k) {
@@ -176,7 +178,7 @@
               i: 0,
               total: 1
             }, esc(__iced_deferrals.defer({
-              lineno: 74
+              lineno: 76
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -192,7 +194,7 @@
                     return fp = arguments[0];
                   };
                 })(),
-                lineno: 75
+                lineno: 77
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -207,7 +209,7 @@
                   i: 1,
                   total: 1
                 }, esc(__iced_deferrals.defer({
-                  lineno: 76
+                  lineno: 78
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -250,7 +252,7 @@
             i: 0,
             total: 1
           }, esc(__iced_deferrals.defer({
-            lineno: 94
+            lineno: 96
           })));
           __iced_deferrals._fulfill();
         });
@@ -268,7 +270,7 @@
                   return opkt = arguments[0];
                 };
               })(),
-              lineno: 95
+              lineno: 97
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -283,7 +285,7 @@
                 i: 1,
                 total: 1
               }, esc(__iced_deferrals.defer({
-                lineno: 96
+                lineno: 98
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -314,7 +316,7 @@
                 return __slot_1._session_key = arguments[0];
               };
             })(_this),
-            lineno: 105
+            lineno: 107
           }));
           __iced_deferrals._fulfill();
         });
@@ -355,7 +357,7 @@
             i: 0,
             total: 1
           }, esc(__iced_deferrals.defer({
-            lineno: 122
+            lineno: 124
           })));
           __iced_deferrals._fulfill();
         });
@@ -375,7 +377,7 @@
                   return ekey = arguments[0];
                 };
               })(),
-              lineno: 123
+              lineno: 125
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -390,7 +392,7 @@
                 i: 1,
                 total: 1
               }, esc(__iced_deferrals.defer({
-                lineno: 124
+                lineno: 126
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -408,7 +410,7 @@
                       i: 0,
                       total: 1
                     }, esc(__iced_deferrals.defer({
-                      lineno: 127
+                      lineno: 129
                     })));
                     __iced_deferrals._fulfill();
                   })(function() {
@@ -424,7 +426,7 @@
                         slosh: (_ref4 = _this.opts.hide) != null ? _ref4.slosh : void 0,
                         key: pub_k
                       }, esc(__iced_deferrals.defer({
-                        lineno: 128
+                        lineno: 130
                       })));
                       __iced_deferrals._fulfill();
                     })(function() {
@@ -439,7 +441,7 @@
                           i: 1,
                           total: 1
                         }, esc(__iced_deferrals.defer({
-                          lineno: 129
+                          lineno: 131
                         })));
                         __iced_deferrals._fulfill();
                       })(__iced_k);
@@ -466,7 +468,7 @@
                         return pkesk = arguments[0];
                       };
                     })(),
-                    lineno: 137
+                    lineno: 139
                   })));
                   __iced_deferrals._fulfill();
                 })(function() {
@@ -517,7 +519,7 @@
                       return pkesk = arguments[0];
                     };
                   })(),
-                  lineno: 146
+                  lineno: 148
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -553,7 +555,7 @@
                 return prefixrandom = arguments[0];
               };
             })(),
-            lineno: 155
+            lineno: 157
           }));
           __iced_deferrals._fulfill();
         });
@@ -573,7 +575,7 @@
               prefixrandom: prefixrandom,
               asp: asp
             }, esc(__iced_deferrals.defer({
-              lineno: 158
+              lineno: 160
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -589,7 +591,7 @@
                     return pkt = arguments[0];
                   };
                 })(),
-                lineno: 159
+                lineno: 161
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -615,7 +617,7 @@
             funcname: "Burner._encrypt"
           });
           _this._make_session_key(esc(__iced_deferrals.defer({
-            lineno: 168
+            lineno: 170
           })));
           __iced_deferrals._fulfill();
         });
@@ -628,7 +630,7 @@
               funcname: "Burner._encrypt"
             });
             _this._encrypt_session_key(esc(__iced_deferrals.defer({
-              lineno: 169
+              lineno: 171
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -639,7 +641,7 @@
                 funcname: "Burner._encrypt"
               });
               _this._encrypt_payload(esc(__iced_deferrals.defer({
-                lineno: 170
+                lineno: 172
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -665,7 +667,7 @@
             funcname: "Burner.burn"
           });
           _this._find_keys(esc(__iced_deferrals.defer({
-            lineno: 181
+            lineno: 183
           })));
           __iced_deferrals._fulfill();
         });
@@ -678,7 +680,7 @@
               funcname: "Burner.burn"
             });
             _this._frame_literals(esc(__iced_deferrals.defer({
-              lineno: 182
+              lineno: 184
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -691,7 +693,7 @@
                     funcname: "Burner.burn"
                   });
                   _this._sign(esc(__iced_deferrals.defer({
-                    lineno: 184
+                    lineno: 186
                   })));
                   __iced_deferrals._fulfill();
                 })(__iced_k);
@@ -706,7 +708,7 @@
                   funcname: "Burner.burn"
                 });
                 _this._compress(esc(__iced_deferrals.defer({
-                  lineno: 185
+                  lineno: 187
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -719,7 +721,7 @@
                         funcname: "Burner.burn"
                       });
                       _this._encrypt(esc(__iced_deferrals.defer({
-                        lineno: 187
+                        lineno: 189
                       })));
                       __iced_deferrals._fulfill();
                     })(__iced_k);
@@ -788,7 +790,7 @@
               return raw = arguments[1];
             };
           })(),
-          lineno: 247
+          lineno: 249
         }));
         __iced_deferrals._fulfill();
       });

--- a/lib/openpgp/clearsign.js
+++ b/lib/openpgp/clearsign.js
@@ -149,7 +149,7 @@
 
   ClearSigner = (function() {
     function ClearSigner(_arg) {
-      this.msg = _arg.msg, this.signing_key = _arg.signing_key, this.now = _arg.now;
+      this.msg = _arg.msg, this.signing_key = _arg.signing_key, this.now = _arg.now, this.hasher = _arg.hasher;
     }
 
     ClearSigner.prototype._fix_msg = function(cb) {
@@ -162,6 +162,7 @@
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       this.sig = new Signature({
+        hasher: this.hasher,
         sig_type: C.sig_types.canonical_text,
         key: this.signing_key.key,
         hashed_subpackets: [new CreationTime(this.now || unix_time())],
@@ -181,7 +182,7 @@
                 return __slot_1._sig_output = arguments[1];
               };
             })(_this),
-            lineno: 117
+            lineno: 118
           }));
           __iced_deferrals._fulfill();
         });
@@ -218,7 +219,7 @@
             funcname: "ClearSigner.run"
           });
           _this._fix_msg(esc(__iced_deferrals.defer({
-            lineno: 139
+            lineno: 140
           })));
           __iced_deferrals._fulfill();
         });
@@ -236,7 +237,7 @@
                   return signature = arguments[0];
                 };
               })(),
-              lineno: 140
+              lineno: 141
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -252,7 +253,7 @@
                     return encoded = arguments[0];
                   };
                 })(),
-                lineno: 141
+                lineno: 142
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -272,7 +273,7 @@
 
     function Verifier(_arg) {
       var keyfetch, packets;
-      packets = _arg.packets, this.clearsign = _arg.clearsign, keyfetch = _arg.keyfetch, this.now = _arg.now;
+      packets = _arg.packets, this.clearsign = _arg.clearsign, keyfetch = _arg.keyfetch, this.now = _arg.now, this.assert_pgp_hash = _arg.assert_pgp_hash;
       Verifier.__super__.constructor.call(this, {
         packets: packets,
         keyfetch: keyfetch
@@ -305,7 +306,8 @@
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       opts = {
-        now: this.now
+        now: this.now,
+        assert_pgp_hash: this.assert_pgp_hash
       };
       (function(_this) {
         return (function(__iced_k) {
@@ -320,7 +322,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 183
+            lineno: 184
           }), opts);
           __iced_deferrals._fulfill();
         });
@@ -358,7 +360,7 @@
             funcname: "Verifier.run"
           });
           _this._check_headers(esc(__iced_deferrals.defer({
-            lineno: 200
+            lineno: 201
           })));
           __iced_deferrals._fulfill();
         });
@@ -371,7 +373,7 @@
               funcname: "Verifier.run"
             });
             _this._find_signature(esc(__iced_deferrals.defer({
-              lineno: 201
+              lineno: 202
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -382,7 +384,7 @@
                 funcname: "Verifier.run"
               });
               _this._reformat_text(esc(__iced_deferrals.defer({
-                lineno: 202
+                lineno: 203
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -393,7 +395,7 @@
                   funcname: "Verifier.run"
                 });
                 _this._fetch_key(esc(__iced_deferrals.defer({
-                  lineno: 203
+                  lineno: 204
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -404,7 +406,7 @@
                     funcname: "Verifier.run"
                   });
                   _this._make_hasher(esc(__iced_deferrals.defer({
-                    lineno: 204
+                    lineno: 205
                   })));
                   __iced_deferrals._fulfill();
                 })(function() {
@@ -415,7 +417,7 @@
                       funcname: "Verifier.run"
                     });
                     _this._verify(esc(__iced_deferrals.defer({
-                      lineno: 205
+                      lineno: 206
                     })));
                     __iced_deferrals._fulfill();
                   })(function() {
@@ -434,14 +436,15 @@
   })(VerifierBase);
 
   exports.sign = function(_arg, cb) {
-    var b, encoded, err, msg, now, signature, signing_key, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+    var b, encoded, err, hasher, msg, now, signature, signing_key, ___iced_passed_deferral, __iced_deferrals, __iced_k;
     __iced_k = __iced_k_noop;
     ___iced_passed_deferral = iced.findDeferral(arguments);
-    msg = _arg.msg, signing_key = _arg.signing_key, now = _arg.now;
+    msg = _arg.msg, signing_key = _arg.signing_key, now = _arg.now, hasher = _arg.hasher;
     b = new ClearSigner({
       msg: msg,
       signing_key: signing_key,
-      now: now
+      now: now,
+      hasher: hasher
     });
     (function(_this) {
       return (function(__iced_k) {
@@ -458,7 +461,7 @@
               return signature = arguments[2];
             };
           })(),
-          lineno: 216
+          lineno: 217
         }));
         __iced_deferrals._fulfill();
       });
@@ -471,15 +474,16 @@
   };
 
   exports.verify = function(_arg, cb) {
-    var clearsign, err, keyfetch, literal, now, packets, v, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+    var assert_pgp_hash, clearsign, err, keyfetch, literal, now, packets, v, ___iced_passed_deferral, __iced_deferrals, __iced_k;
     __iced_k = __iced_k_noop;
     ___iced_passed_deferral = iced.findDeferral(arguments);
-    packets = _arg.packets, clearsign = _arg.clearsign, keyfetch = _arg.keyfetch, now = _arg.now;
+    packets = _arg.packets, clearsign = _arg.clearsign, keyfetch = _arg.keyfetch, now = _arg.now, assert_pgp_hash = _arg.assert_pgp_hash;
     v = new Verifier({
       packets: packets,
       clearsign: clearsign,
       keyfetch: keyfetch,
-      now: now
+      now: now,
+      assert_pgp_hash: assert_pgp_hash
     });
     (function(_this) {
       return (function(__iced_k) {
@@ -495,7 +499,7 @@
               return literal = arguments[1];
             };
           })(),
-          lineno: 224
+          lineno: 225
         }));
         __iced_deferrals._fulfill();
       });

--- a/lib/openpgp/detachsign.js
+++ b/lib/openpgp/detachsign.js
@@ -130,7 +130,7 @@
                 return __slot_1._sig_output = arguments[1];
               };
             })(_this),
-            lineno: 60
+            lineno: 59
           }));
           __iced_deferrals._fulfill();
         });
@@ -171,7 +171,7 @@
 
     function Verifier(_arg) {
       var keyfetch, packets;
-      packets = _arg.packets, this.data = _arg.data, this.data_fn = _arg.data_fn, keyfetch = _arg.keyfetch, this.now = _arg.now;
+      packets = _arg.packets, this.data = _arg.data, this.data_fn = _arg.data_fn, keyfetch = _arg.keyfetch, this.now = _arg.now, this.assert_pgp_hash = _arg.assert_pgp_hash;
       Verifier.__super__.constructor.call(this, {
         packets: packets,
         keyfetch: keyfetch
@@ -220,7 +220,7 @@
                           return done = arguments[1];
                         };
                       })(),
-                      lineno: 102
+                      lineno: 101
                     }));
                     __iced_deferrals._fulfill();
                   })(function() {
@@ -254,7 +254,8 @@
       ] : [];
       this.literals = data;
       opts = {
-        now: this.now
+        now: this.now,
+        assert_pgp_hash: this.assert_pgp_hash
       };
       (function(_this) {
         return (function(__iced_k) {
@@ -269,7 +270,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 114
+            lineno: 113
           }), opts);
           __iced_deferrals._fulfill();
         });
@@ -305,7 +306,7 @@
             funcname: "Verifier.run"
           });
           _this._find_signature(esc(__iced_deferrals.defer({
-            lineno: 129
+            lineno: 128
           })));
           __iced_deferrals._fulfill();
         });
@@ -318,7 +319,7 @@
               funcname: "Verifier.run"
             });
             _this._fetch_key(esc(__iced_deferrals.defer({
-              lineno: 130
+              lineno: 129
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -329,7 +330,7 @@
                 funcname: "Verifier.run"
               });
               _this._consume_data(esc(__iced_deferrals.defer({
-                lineno: 131
+                lineno: 130
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -340,7 +341,7 @@
                   funcname: "Verifier.run"
                 });
                 _this._verify(esc(__iced_deferrals.defer({
-                  lineno: 132
+                  lineno: 131
                 })));
                 __iced_deferrals._fulfill();
               })(function() {
@@ -351,7 +352,7 @@
                     funcname: "Verifier.run"
                   });
                   _this._make_literals(esc(__iced_deferrals.defer({
-                    lineno: 133
+                    lineno: 132
                   })));
                   __iced_deferrals._fulfill();
                 })(function() {
@@ -394,7 +395,7 @@
               return signature = arguments[2];
             };
           })(),
-          lineno: 140
+          lineno: 139
         }));
         __iced_deferrals._fulfill();
       });
@@ -407,16 +408,17 @@
   };
 
   exports.verify = function(_arg, cb) {
-    var data, data_fn, err, keyfetch, literals, now, packets, v, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+    var assert_pgp_hash, data, data_fn, err, keyfetch, literals, now, packets, v, ___iced_passed_deferral, __iced_deferrals, __iced_k;
     __iced_k = __iced_k_noop;
     ___iced_passed_deferral = iced.findDeferral(arguments);
-    data = _arg.data, data_fn = _arg.data_fn, packets = _arg.packets, keyfetch = _arg.keyfetch, now = _arg.now;
+    data = _arg.data, data_fn = _arg.data_fn, packets = _arg.packets, keyfetch = _arg.keyfetch, now = _arg.now, assert_pgp_hash = _arg.assert_pgp_hash;
     v = new Verifier({
       data: data,
       data_fn: data_fn,
       packets: packets,
       keyfetch: keyfetch,
-      now: now
+      now: now,
+      assert_pgp_hash: assert_pgp_hash
     });
     (function(_this) {
       return (function(__iced_k) {
@@ -432,7 +434,7 @@
               return literals = arguments[1];
             };
           })(),
-          lineno: 148
+          lineno: 147
         }));
         __iced_deferrals._fulfill();
       });

--- a/lib/openpgp/packet/signature.js
+++ b/lib/openpgp/packet/signature.js
@@ -363,6 +363,9 @@
       var err, p, s, subkey, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
+      if (err = opts != null ? typeof opts.assert_pgp_hash === "function" ? opts.assert_pgp_hash(this.hasher, this) : void 0 : void 0) {
+        return cb(err);
+      }
       (function(_this) {
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
@@ -376,7 +379,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 210
+            lineno: 213
           }), opts);
           __iced_deferrals._fulfill();
         });
@@ -401,7 +404,7 @@
                 return _break();
               } else {
                 p = _ref3[_i];
-                if ((typeof err === "undefined" || err === null) && ((s = p.to_sig()) != null)) {
+                if ((err == null) && ((s = p.to_sig()) != null)) {
                   (function(__iced_k) {
                     if (s.type !== C.sig_types.primary_binding) {
                       return __iced_k(err = new Error("unknown subpacket signature type: " + s.type));
@@ -426,7 +429,7 @@
                                   return err = arguments[0];
                                 };
                               })(),
-                              lineno: 221
+                              lineno: 224
                             }), opts);
                             __iced_deferrals._fulfill();
                           })(__iced_k);
@@ -524,7 +527,7 @@
                     return err = arguments[0];
                   };
                 })(),
-                lineno: 273
+                lineno: 276
               }));
               __iced_deferrals._fulfill();
             })(__iced_k);
@@ -670,7 +673,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 349
+            lineno: 352
           }));
           __iced_deferrals._fulfill();
         });

--- a/lib/openpgp/processor.js
+++ b/lib/openpgp/processor.js
@@ -270,7 +270,7 @@ _continue()
 
   Message = (function() {
     function Message(_arg) {
-      this.keyfetch = _arg.keyfetch, this.data_fn = _arg.data_fn, this.data = _arg.data, this.strict = _arg.strict, this.now = _arg.now;
+      this.keyfetch = _arg.keyfetch, this.data_fn = _arg.data_fn, this.data = _arg.data, this.strict = _arg.strict, this.now = _arg.now, this.assert_pgp_hash = _arg.assert_pgp_hash;
       this.literals = [];
       this.enc_data_packet = null;
       this.warnings = new Warnings();
@@ -672,7 +672,8 @@ _continue()
                   })(),
                   lineno: 289
                 }), {
-                  now: _this.now
+                  now: _this.now,
+                  assert_pgp_hash: _this.assert_pgp_hash
                 });
                 __iced_deferrals._fulfill();
               })(__iced_k);
@@ -817,7 +818,8 @@ _continue()
                 packets: packets,
                 clearsign: clearsign,
                 keyfetch: _this.keyfetch,
-                now: _this.now
+                now: _this.now,
+                assert_pgp_hash: _this.assert_pgp_hash
               }, __iced_deferrals.defer({
                 assign_fn: (function() {
                   return function() {
@@ -949,7 +951,8 @@ _continue()
                 data: _this.data,
                 data_fn: _this.data_fn,
                 keyfetch: _this.keyfetch,
-                now: _this.now
+                now: _this.now,
+                assert_pgp_hash: _this.assert_pgp_hash
               }, __iced_deferrals.defer({
                 assign_fn: (function() {
                   return function() {

--- a/lib/openpgp/sigeng.js
+++ b/lib/openpgp/sigeng.js
@@ -54,17 +54,19 @@
       return this.km;
     };
 
-    SignatureEngine.prototype.box = function(msg, cb, _arg) {
-      var err, out, prefix, signing_key, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+    SignatureEngine.prototype.box = function(msg, cb, opts) {
+      var err, out, signing_key, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
-      prefix = (_arg != null ? _arg : {}).prefix;
+      if (opts == null) {
+        opts = {};
+      }
       out = {
         type: "pgp"
       };
       (function(_this) {
         return (function(__iced_k) {
-          if (prefix != null) {
+          if (opts.prefix != null) {
             return __iced_k(err = new Error("prefixes cannot be used with PGP"));
           } else {
             (function(__iced_k) {
@@ -77,7 +79,8 @@
                   });
                   burn({
                     msg: msg,
-                    signing_key: signing_key
+                    signing_key: signing_key,
+                    opts: opts
                   }, __iced_deferrals.defer({
                     assign_fn: (function(__slot_1, __slot_2) {
                       return function() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "keybase"
   ],
   "author": "Maxwell Krohn",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "license": "BSD-3-Clause",
   "main": "./lib/main.js",
   "directories": {

--- a/src/openpgp/burner.iced
+++ b/src/openpgp/burner.iced
@@ -57,10 +57,11 @@ class Burner extends BaseBurner
   #------------
 
   _sign : (cb) ->
-    esc = make_esc cb, "Burner::_sign'"
+    esc = make_esc cb, "Burner::_sign"
+    hasher = @opts?.hasher ? SHA512
     ops = new OnePassSignature {
       sig_type : C.sig_types.binary_doc,
-      hasher : SHA512
+      hasher
       sig_klass : @signing_key.get_klass()
       key_id : @signing_key.get_key_id()
       is_final : 1
@@ -68,6 +69,7 @@ class Burner extends BaseBurner
     await ops.write esc defer ops_framed
     sig = new Signature {
       type : C.sig_types.binary_doc
+      hasher
       key : @signing_key.key
       hashed_subpackets : [ new CreationTime(@opts?.now or unix_time()) ]
       unhashed_subpackets : [ new Issuer @signing_key.get_key_id() ]

--- a/src/openpgp/detachsign.iced
+++ b/src/openpgp/detachsign.iced
@@ -49,7 +49,6 @@ class Signer
   #---------------------------------------------------
 
   _sign : (cb) ->
-
     @sig = new Signature {
       sig_type : C.sig_types.canonical_text,
       key : @signing_key.key,
@@ -86,7 +85,7 @@ class Verifier extends VerifierBase
 
   #-----------------------
 
-  constructor : ({packets, @data, @data_fn, keyfetch, @now}) ->
+  constructor : ({packets, @data, @data_fn, keyfetch, @now, @assert_pgp_hash}) ->
     super { packets, keyfetch }
 
   #-----------------------
@@ -111,7 +110,7 @@ class Verifier extends VerifierBase
     data = if @data then [ new Literal  { @data } ]
     else []
     @literals = data
-    opts = {@now}
+    opts = {@now, @assert_pgp_hash}
     await @_sig.verify data, defer(err), opts
     cb err
 
@@ -144,10 +143,9 @@ exports.sign = ({data, hash_streamer, signing_key, now }, cb) ->
 
 #====================================================================
 
-exports.verify = ({data, data_fn, packets, keyfetch, now }, cb) ->
-  v = new Verifier { data, data_fn, packets, keyfetch, now }
+exports.verify = ({data, data_fn, packets, keyfetch, now, assert_pgp_hash }, cb) ->
+  v = new Verifier { data, data_fn, packets, keyfetch, now, assert_pgp_hash }
   await v.run defer err, literals
   cb err, literals
 
 #====================================================================
-

--- a/src/openpgp/packet/signature.iced
+++ b/src/openpgp/packet/signature.iced
@@ -208,6 +208,9 @@ class Signature extends Packet
   #-----------------
 
   verify : (data_packets, cb, opts) ->
+    if err = opts?.assert_pgp_hash?(@hasher, @)
+      # Caller disallows use of this hash algo.
+      return cb err
     await @_verify data_packets, defer(err), opts
     for p in @unhashed_subpackets when (not err? and (s = p.to_sig())?)
       if s.type isnt C.sig_types.primary_binding
@@ -827,5 +830,3 @@ exports.EmbeddedSignature = EmbeddedSignature
 exports.PrimaryUserId = PrimaryUserId
 
 #===========================================================
-
-

--- a/src/openpgp/processor.iced
+++ b/src/openpgp/processor.iced
@@ -152,7 +152,7 @@ class Message
 
   #---------
 
-  constructor : ({@keyfetch, @data_fn, @data, @strict, @now}) ->
+  constructor : ({@keyfetch, @data_fn, @data, @strict, @now, @assert_pgp_hash}) ->
     @literals = []
     @enc_data_packet = null
     @warnings = new Warnings()
@@ -287,7 +287,7 @@ class Message
 
       # If this succeeds, then we'll go through and mark each
       # packet in sig.payload with the successful sig.close.
-      await sig.close.verify sig.payload, defer(err), { @now }
+      await sig.close.verify sig.payload, defer(err), { @now, @assert_pgp_hash }
 
     else if not @strict
       @warnings.push "Problem fetching key #{a.toString('hex')}: #{err.toString()}"
@@ -325,7 +325,7 @@ class Message
     if not clearsign?
       err = new Error "no clearsign data found"
     else
-      await verify_clearsign { packets, clearsign, @keyfetch, @now }, defer err, literal
+      await verify_clearsign { packets, clearsign, @keyfetch, @now, @assert_pgp_hash }, defer err, literal
     cb err, [ literal ]
 
   #---------
@@ -350,7 +350,7 @@ class Message
     if not(@data? or @data_fn?)
       err = new Error "Cannot verify detached signature without data input"
     else
-      await verify_detached { packets, @data, @data_fn, @keyfetch, @now}, defer err, literals
+      await verify_detached { packets, @data, @data_fn, @keyfetch, @now, @assert_pgp_hash }, defer err, literals
     cb err, literals
 
   #---------

--- a/src/openpgp/sigeng.iced
+++ b/src/openpgp/sigeng.iced
@@ -32,11 +32,11 @@ exports.SignatureEngine = class SignatureEngine extends SignatureEngineInterface
 
   #-----
 
-  box         : (msg, cb, {prefix} = {}) ->
+  box         : (msg, cb, opts = {}) ->
     out = { type : "pgp" }
-    if prefix? then err = new Error "prefixes cannot be used with PGP"
+    if opts.prefix? then err = new Error "prefixes cannot be used with PGP"
     else if (signing_key = @km.find_signing_pgp_key())?
-      await burn { msg, signing_key }, defer err, out.pgp, out.raw
+      await burn { msg, signing_key, opts }, defer err, out.pgp, out.raw
       out.armored = out.pgp unless err?
     else err = new Error "No signing key found"
     cb err, out

--- a/test/browser/main.iced
+++ b/test/browser/main.iced
@@ -3,6 +3,7 @@ mods =
   brainpool256 : require '../files/brainpool256.iced'
   brainpool384: require '../files/brainpool384.iced'
   brainpool512: require '../files/brainpool512.iced'
+  burner: require '../files/burner.iced'
   eddsa : require '../files/eddsa.iced'
   box : require '../files/box.iced'
   kbbox : require '../files/kbbox.iced'

--- a/test/files/burner.iced
+++ b/test/files/burner.iced
@@ -1,0 +1,154 @@
+kbpgp = require '../../'
+{KeyManager} = kbpgp
+{make_esc} = require 'iced-error'
+
+{OnePassSignature} = require '../../lib/openpgp/packet/one_pass_sig'
+{Literal} = require '../../lib/openpgp/packet/literal'
+{Signature, CreationTime, Issuer} = require '../../lib/openpgp/packet/signature'
+
+C = kbpgp.const.openpgp
+{ecc, hash, armor} = kbpgp
+{Message} = kbpgp.processor
+
+km = null
+
+exports.init = (T, cb) ->
+  esc = make_esc cb
+  F = C.key_flags
+  keygen_arg = {
+    userid: "burner.iced test"
+    primary: { flags: F.sign_data | F.certify_keys, algo : ecc.EDDSA }
+    subkeys: [{ flags: F.encrypt_storage | F.encrypt_conn, algo : ecc.ECDH, curve_name: 'NIST P-384' }]
+  }
+  await KeyManager.generate keygen_arg, esc defer km
+  cb null
+
+exports.burn_with_hasher = (T, cb) ->
+  esc = make_esc cb
+
+  msg_plain = 'hello world\n'
+
+  sig_eng = km.make_sig_eng()
+  await sig_eng.box msg_plain, esc(defer(res)), { hasher: hash.SHA1 }
+  pgp_res = res.pgp
+
+  # Parse the message back
+  msg = new Message {}
+  await msg.parse_and_inflate res.raw, esc defer()
+
+  T.equal msg.packets.length, 3
+  # Except the following packet types
+  for typ, index in [OnePassSignature, Literal, Signature]
+    T.assert (p = msg.packets[index]) instanceof typ
+    # Check if OnePassSignature and Signature have the correct hasher.
+    if index in [0, 2]
+      T.equal p.hasher.algname, 'SHA1'
+      T.equal p.hasher.type, 2
+      T.equal p.hasher.klass, hash.SHA1.klass
+
+  # Try to verify the message
+  sig_eng = km.make_sig_eng()
+  await sig_eng.unbox pgp_res, esc defer res
+  T.equal res.toString(), msg_plain
+
+  assert_pgp_hash = (hasher) ->
+    if hasher.algname is 'SHA1' then new Error 'found sha1 hash'
+  await sig_eng.unbox pgp_res, (defer err, res), { assert_pgp_hash }
+  T.equal err?.message, 'found sha1 hash'
+  T.assert not res?
+
+  cb null
+
+unpack_pgp_message = ({raw, armored}, cb) ->
+  esc = make_esc cb
+  if armored?
+    [err,msg] = armor.decode armored
+    if err then return cb err
+    raw = msg.body
+  msg = new Message {}
+  await msg.parse_and_inflate raw, esc defer()
+  cb null, msg
+
+assert_hasher = ({T, msg, hasher, tag}) ->
+  for p in msg.packets when p.hasher?
+    T.equal p.hasher.algname, hasher.algname, "wrong hasher at #{tag}"
+    T.equal p.hasher.type, hasher.type
+    T.equal p.hasher.klass, hasher.klass
+
+exports.burn_with_hasher_2 = (T, cb) ->
+  # However, there are more ways to burn a message.
+  esc = make_esc cb
+
+  hasher = hash.SHA256
+  msg_plain = 'but the future refused to change'
+
+  await kbpgp.burn { msg: msg_plain, sign_with: km, opts: { hasher } }, esc defer res
+  await unpack_pgp_message { T, armored: res }, esc defer msg
+  assert_hasher { T, msg, hasher, tag: 'generic' }
+
+  await kbpgp.clearsign { msg: msg_plain, signing_key: km.primary._pgp, hasher }, esc defer res
+  await unpack_pgp_message { T, armored: res }, esc defer msg
+  assert_hasher { T, msg, hasher, tag: 'clear' }
+
+  # To pass hasher to detachsign, use `hash_streamer`.
+  hash_streamer = hash.streamers.SHA256()
+  hash_streamer.update Buffer.from msg_plain
+  await kbpgp.detachsign { signing_key: km.primary._pgp, hash_streamer }, esc defer res
+  await unpack_pgp_message { T, armored: res }, esc defer msg
+  assert_hasher { T, msg, hasher, tag: 'detach' }
+
+  cb null
+
+exports.burner_default_hash = (T, cb) ->
+  # Make sure there are reasonable defaults when hasher is not specified.
+  esc = make_esc cb
+
+  msg_plain = 'hell world\n\n'
+  sig_eng = km.make_sig_eng()
+  await sig_eng.box msg_plain, esc defer res
+
+  msg = new Message {}
+  await msg.parse_and_inflate res.raw, esc defer()
+
+  T.equal msg.packets.length, 3
+  for typ, index in [OnePassSignature, Literal, Signature]
+    T.assert (p = msg.packets[index]) instanceof typ
+    if index in [0, 2]
+      T.equal p.hasher.algname, 'SHA512'
+      T.equal p.hasher.type, 10
+      T.equal p.hasher.klass, hash.SHA512.klass
+
+  cb null
+
+exports.assert_pgp_hash = (T, cb) ->
+  # Test assert_pgp_hash with different message types.
+  esc = make_esc cb
+  hasher = hash.MD5
+  msg_plain = 'Could a machine think? Could the mind itself be a thinking machine?'
+
+  sig_eng = km.make_sig_eng()
+
+  assert_pgp_hash = (hasher) ->
+    if (hn = hasher.algname) in ['SHA1', 'MD5']
+      new Error "found insecure #{hn} hash"
+
+  # Generic messages are already tested in `burn_with_hasher` test
+  # through `unbox` API.
+
+  await kbpgp.clearsign { msg: msg_plain, signing_key: km.primary._pgp, hasher }, esc defer res
+  [err,decoded] = armor.decode res
+  T.no_error err
+  msg = new Message { keyfetch: km, assert_pgp_hash }
+  await msg.parse_and_process decoded, defer err
+  T.equal err?.message, "found insecure MD5 hash"
+
+  hash_streamer = hash.streamers.SHA1()
+  hash_streamer.update Buffer.from msg_plain
+  await kbpgp.detachsign { signing_key: km.primary._pgp, hash_streamer }, esc defer res
+  [err,decoded] = armor.decode res
+  T.no_error err
+  msg = new Message { keyfetch: km, assert_pgp_hash, data: Buffer.from(msg_plain) }
+  await msg.parse_and_process decoded, defer err
+  T.equal err?.message, "found insecure SHA1 hash"
+
+  cb null

--- a/test/files/elgamal.iced
+++ b/test/files/elgamal.iced
@@ -1,5 +1,5 @@
 {KeyManager} = require '../../'
-{do_message,Processor} = require '../../lib/openpgp/processor'
+{do_message} = require '../../lib/openpgp/processor'
 {burn} = require '../../lib/openpgp/burner'
 
 testing_unixtime = Math.floor(new Date(2014, 2, 21)/1000)
@@ -146,4 +146,3 @@ exports.elgamal_round_trip = (T,cb) ->
   cb()
 
 #=================================================================
-

--- a/test/files/sig_v3.iced
+++ b/test/files/sig_v3.iced
@@ -1,7 +1,7 @@
 testing_unixtime = Math.floor(new Date(2014, 2, 20)/1000)
 
 {KeyManager} = require '../../'
-{do_message,Processor} = require '../../lib/openpgp/processor'
+{do_message} = require '../../lib/openpgp/processor'
 
 #==================================================================
 
@@ -163,4 +163,3 @@ exports.verify = (T,cb) ->
   cb()
 
 #==================================================================
-


### PR DESCRIPTION
Add a way to pass `hasher` to boxing / signing functions. Right now it's only used to create messages for tests.

Add `assert_pgp_hash` callback argument to unboxing / verifying functions. It's called whenever a hash is encountered and provides an ability to return an error and fail the verification if we don't like the hash algo.